### PR TITLE
Update INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,8 +1,8 @@
 ## INSTALL
 
-1. [Install brew](https://brew.sh/)
-2. [Install chocolatey](https://chocolatey.org/) for winodws
-3. [Install node version manager](https://github.com/nvm-sh/nvm/blob/master/README.md)
+1. [Install brew](https://brew.sh/) for Mac
+2. [Install chocolatey](https://chocolatey.org/) for Windows
+3. [Install node version manager](https://github.com/nvm-sh/nvm/blob/master/README.md): go to section Install & Update Script
 
 #### Install node with brew
 


### PR DESCRIPTION
-The link under INSTALL is not valid in readme Quick start Guide section: Make sure npm, node is install by following the INSTALL.

-Need to remove the following outdated code in Quick Start Guide: "npm run dev
cd client
npm run dev"

-The current version of node is v18.12.1.  I am not sure if we need to update the following instruction under INSTALL.md: 
''Install node with brew
brew install node
node --version
18.0.0''

##### Status

ready or not ready

##### Description

Please include a short summary of the changes and the related issue.

##### What was change
